### PR TITLE
Scope each request

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -64,7 +64,7 @@ const once = require('once')
  * @property {middlewareFunction} onError - the middleware function to attach as *error* middleware
  */
 
-const runMiddlewares = (middlewares, instance, done) => {
+const runMiddlewares = (middlewares, request, done) => {
   const stack = Array.from(middlewares)
   const runNext = (err) => {
     try {
@@ -75,7 +75,7 @@ const runMiddlewares = (middlewares, instance, done) => {
       const nextMiddleware = stack.shift()
 
       if (nextMiddleware) {
-        const retVal = nextMiddleware(instance, runNext)
+        const retVal = nextMiddleware(request, runNext)
 
         if (retVal) {
           if (!isPromise(retVal)) {
@@ -99,19 +99,19 @@ const runMiddlewares = (middlewares, instance, done) => {
   runNext()
 }
 
-const runErrorMiddlewares = (middlewares, instance, done) => {
+const runErrorMiddlewares = (middlewares, request, done) => {
   const stack = Array.from(middlewares)
-  instance.__handledError = false
+  request.__handledError = false
   const runNext = (err) => {
     try {
       if (!err) {
-        instance.__handledError = true
+        request.__handledError = true
       }
 
       const nextMiddleware = stack.shift()
 
       if (nextMiddleware) {
-        const retVal = nextMiddleware(instance, runNext)
+        const retVal = nextMiddleware(request, runNext)
 
         if (retVal) {
           if (!isPromise(retVal)) {
@@ -129,13 +129,13 @@ const runErrorMiddlewares = (middlewares, instance, done) => {
         return
       }
 
-      return done(instance.__handledError ? null : err)
+      return done(request.__handledError ? null : err)
     } catch (err) {
       return done(err)
     }
   }
 
-  runNext(instance.error)
+  runNext(request.error)
 }
 
 /**
@@ -149,11 +149,12 @@ const middy = (handler) => {
   const errorMiddlewares = []
 
   const instance = (event, context, callback) => {
-    instance.event = event
-    instance.context = context
-    instance.callback = callback
-    instance.response = null
-    instance.error = null
+    const request = {}
+    request.event = event
+    request.context = context
+    request.callback = callback
+    request.response = null
+    request.error = null
 
     const middyPromise = new Promise((resolve, reject) => {
       const terminate = (err) => {
@@ -161,32 +162,32 @@ const middy = (handler) => {
           return callback ? callback(err) : reject(err)
         }
 
-        return callback ? callback(null, instance.response) : resolve(instance.response)
+        return callback ? callback(null, request.response) : resolve(request.response)
       }
 
       const errorHandler = err => {
-        instance.error = err
-        return runErrorMiddlewares(errorMiddlewares, instance, terminate)
+        request.error = err
+        return runErrorMiddlewares(errorMiddlewares, request, terminate)
       }
 
-      runMiddlewares(beforeMiddlewares, instance, (err) => {
+      runMiddlewares(beforeMiddlewares, request, (err) => {
         if (err) return errorHandler(err)
 
         const onHandlerError = once((err) => {
-          instance.response = null
+          request.response = null
           errorHandler(err)
         })
 
         const onHandlerSuccess = once((response) => {
-          instance.response = response
-          runMiddlewares(afterMiddlewares, instance, (err) => {
+          request.response = response
+          runMiddlewares(afterMiddlewares, request, (err) => {
             if (err) return errorHandler(err)
 
             terminate()
           })
         })
 
-        const handlerReturnValue = handler.call(instance, instance.event, context, (err, response) => {
+        const handlerReturnValue = handler.call(instance, request.event, context, (err, response) => {
           if (err) return onHandlerError(err)
           onHandlerSuccess(response)
         })


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes -> https://codesandbox.io/s/purple-star-n3ohc?file=/src/index.js

This scopes the request object to an individual request.  This allows for calling a wrapped handler multiple times concurrently.  This is useful when trying to reuse individual handlers when batching.  Without this a handler may receive the wrong request or return the incorrect response when calling concurrently.

Does this close any currently open issues?
------------------------------------------
https://github.com/middyjs/middy/issues/558


Any other comments?
-------------------

This could be considered a breaking change if someone was mutating the handler object intending it to persist between requests.  
That being said there would be no reason to store your global state on the handler itself unless you thought it was scoped per request which this implements.

Where has this been tested?
---------------------------
**Node.js Versions:** 10/12

**Middy Versions:** 1.2.0

**AWS SDK Versions:** 2.713.0

Todo list
---------

[x] Feature/Fix fully implemented
[ ] Added tests
[ ] Updated relevant documentation
[ ] Updated relevant examples
